### PR TITLE
general: platforms: Update AM65x site link

### DIFF
--- a/general/platforms.rst
+++ b/general/platforms.rst
@@ -213,7 +213,7 @@ please refer to the file MAINTAINERS_ for contact details for various platforms.
      - Yes
      - Yes
 
-   * - `Texas Instruments AM65x <http://www.ti.com/lit/ug/spruid7/spruid7.pdf>`_
+   * - `Texas Instruments AM65x <http://www.ti.com/processors/sitara-arm/am6x-cortex-a53-r5/overview.html>`_
      - ``PLATFORM=k3-am65x``
      - Yes
      - Yes


### PR DESCRIPTION
The old link was a pre-product launch datasheet, update this link
to the new device landing page.

Signed-off-by: Andrew F. Davis <afd@ti.com>