### PR TITLE
qemu: gdb: use hbreak instead of break to halt in OP-TEE core

### DIFF
--- a/building/devices/qemu.rst
+++ b/building/devices/qemu.rst
@@ -166,8 +166,8 @@ Now you can set a breakpoint for any symbol in OP-TEE, for example
 
 .. code-block:: none
 
-    (gdb) b tee_entry_std
-    Breakpoint 1 at 0xe103012: file core/arch/arm/tee/entry_std.c, line 526.
+    (gdb) hbreak tee_entry_std
+    Hardware assisted breakpoint 1 at 0xe103012: file core/arch/arm/tee/entry_std.c, line 526.
 
 Last step is to initiate the boot, do that also from the GDB console
 


### PR DESCRIPTION
Replace GDB break instruction with hbreak since software break
point can be dropped when OP-TEE core instructions are loaded in
memory. This may happen if break point is set before OP-TEE images
are loaded by the bootloader or when OP-TEE pager loads pageable
instructions at runtime.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>