### PR TITLE
Fixes related to section syntax

### DIFF
--- a/architecture/globalplatform_api.rst
+++ b/architecture/globalplatform_api.rst
@@ -120,6 +120,9 @@ to import the definitions of the extensions. For each extension, a configuration
 directive prefixed ``CFG_`` allows one to disable support for the extension when
 building the OP-TEE packages.
 
+
+.. _extensions_cache_maintenance:
+
 Cache Maintenance Support
 =========================
 Following functions have been introduced in order to allow Trusted Applications
@@ -132,10 +135,10 @@ to operate with the data cache:
     TEE_Result TEE_CacheInvalidate(char *buf, size_t len);
 
 These functions are available to any Trusted Application defined with the flag
-``TA_FLAG_CACHE_MAINTENANCE`` sets on. When not set, each function returns the
-error code ``TEE_ERROR_NOT_SUPPORTED``. Within these extensions, a Trusted
-Application is able to operate on the data cache, with the following
-specification:
+``TA_FLAG_CACHE_MAINTENANCE`` sets on, see :ref:`ta_property_cache_maintenance`.
+When not set, each function returns the error code ``TEE_ERROR_NOT_SUPPORTED``.
+Within these extensions, a Trusted Application is able to operate on the data
+cache, with the following specification:
 
 .. list-table::
     :widths: 10 60
@@ -162,7 +165,6 @@ returned:
     - The memory range has not the write access, that is
       ``TEE_MEMORY_ACCESS_WRITE`` is not set.
     - The memory is **not** user space memory.
-
 
 You may disable this extension by setting the following configuration variable
 in ``conf.mk``:

--- a/architecture/trusted_applications.rst
+++ b/architecture/trusted_applications.rst
@@ -180,15 +180,16 @@ Refer to the OP-TEE OS for secure data path support. TAs that do not set
 to handle memory reference invocation parameters that relate to secure data path
 buffers.
 
+.. _ta_property_cache_maintenance:
 
 Cache maintenance Flag
 ----------------------
 ``TA_FLAG_CACHE_MAINTENANCE`` is a bit flag supported by ``TA_FLAGS``. This
-property flag claims access to the cache maintenance API for the TA:
-``TEE_CacheXxxx()``. Refer to the OP-TEE to check if cache API support is
-enabled. TAs that do not set ``TA_FLAG_CACHE_MAINTENANCE`` in the value of their
-``TA_FLAGS`` will not be able to call the cache maintenance API.
-
+property flag, when enabled, allows Trusted Applciation to use the cache
+maintenance API extension of the Internal Core API described in
+:ref:`extensions_cache_maintenance`. TAs that do not set
+``TA_FLAG_CACHE_MAINTENANCE`` in the value of their ``TA_FLAGS`` will not be
+able to call the cache maintenance API.
 
 Deprecated Property Flags
 -------------------------

--- a/architecture/trusted_applications.rst
+++ b/architecture/trusted_applications.rst
@@ -106,13 +106,13 @@ TA Properties
 This section give a more in depth description of the TA properties (see
 :ref:`build_trusted_applications` also).
 
-1. GlobalPlatform properties
-============================
+GlobalPlatform Properties
+=========================
 Standard TA properties must be defined through property flag in macro
 ``TA_FLAGS`` in ``user_ta_header_defines.h``
 
-1.1 Single Instance
-===================
+Single Instance
+---------------
 ``"gpd.ta.singleInstance"`` is a boolean property of the TA. This property
 defines if one instance of the TA must be created and will receive all open
 session request, or if a new specific TA instance must be created for each
@@ -121,8 +121,8 @@ to configuration of this property. The boolean property is set to ``true`` if
 ``TA_FLAGS`` sets bit ``TA_FLAG_SINGLE_INSTANCE``, otherwise the boolean
 property is set to ``false``.
 
-1.2 Multi-session
-=================
+Multi-session
+-------------
 ``"gpd.ta.multiSession"`` is a boolean property of the TA. This property defines
 if the TA instance can handle several sessions. If disabled, TA instance support
 only one session. In such case, if the TA already has a opened session, any open
@@ -136,8 +136,8 @@ OP-TEE TA flag ``TA_FLAG_MULTI_SESSION`` sets to configuration of this property.
 The boolean property is set to ``true`` if ``TA_FLAGS`` sets bit
 ``TA_FLAG_MULTI_SESSION``, otherwise the boolean property is set to ``false``.
 
-1.3 Keep Alive
-==============
+Keep Alive
+----------
 ``"gpd.ta.instanceKeepAlive"`` is a boolean property of the TA. This property
 defines if the TA instance created must be destroyed or not when all sessions
 opened towards the TA are closed. If the property is enabled, TA instance, once
@@ -153,26 +153,26 @@ property. The boolean property is set to ``true`` if ``TA_FLAGS`` sets bit
 ``TA_FLAG_INSTANCE_KEEP_ALIVE``, otherwise the boolean property is set to
 ``false``.
 
-1.4 Heap Size
-=============
+Heap Size
+---------
 ``"gpd.ta.dataSize"`` is a 32bit integer property of the TA. This property
 defines the size in bytes of the TA allocation pool, in which ``TEE_Malloc()``
 and friends allocate memory. The value of the property must be defined by the
 macro ``TA_DATA_SIZE`` in ``user_ta_header_defines.h`` (see
 :ref:`build_ta_properties`).
 
-1.5 Stack Size
-==============
+Stack Size
+----------
 ``"gpd.ta.stackSize"`` is a 32bit integer property of the TA. This property
 defines the size in bytes of the stack used for TA execution. The value of the
 property must be defined by the macro ``TA_STACK_SIZE`` in
 ``user_ta_header_defines.h`` (see :ref:`build_ta_properties`).
 
-2. Property extensions
-======================
+Property Extensions
+===================
 
-2.1 Secure Data Path Flag
-=========================
+Secure Data Path Flag
+---------------------
 ``TA_FLAG_SECURE_DATA_PATH`` is a bit flag supported by ``TA_FLAGS``. This
 property flag claims the secure data support from the OP-TEE OS for the TA.
 Refer to the OP-TEE OS for secure data path support. TAs that do not set
@@ -180,20 +180,21 @@ Refer to the OP-TEE OS for secure data path support. TAs that do not set
 to handle memory reference invocation parameters that relate to secure data path
 buffers.
 
-2.2 Cache maintenance Flag
-==========================
+
+Cache maintenance Flag
+----------------------
 ``TA_FLAG_CACHE_MAINTENANCE`` is a bit flag supported by ``TA_FLAGS``. This
 property flag claims access to the cache maintenance API for the TA:
 ``TEE_CacheXxxx()``. Refer to the OP-TEE to check if cache API support is
 enabled. TAs that do not set ``TA_FLAG_CACHE_MAINTENANCE`` in the value of their
 ``TA_FLAGS`` will not be able to call the cache maintenance API.
 
-.. _ELF: https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
-.. _early TA commit: https://github.com/OP-TEE/optee_os/commit/d0c636148b3a
 
-2.3 Deprecated Property Flags
-=============================
-
+Deprecated Property Flags
+-------------------------
 Older versions of OP-TEE used to define extended property flags that are
 deprecated and meaningless to current OP-TEE. These are ``TA_FLAG_USER_MODE``,
 ``TA_FLAG_EXEC_DDR`` and ``TA_FLAG_REMAP_SUPPORT``.
+
+.. _ELF: https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
+.. _early TA commit: https://github.com/OP-TEE/optee_os/commit/d0c636148b3a

--- a/building/toolchains.rst
+++ b/building/toolchains.rst
@@ -14,8 +14,8 @@ Download/install
 We propose two ways to download the toolchains, both will put the toolchains
 under the same path(s).
 
-1. Direct download
-==================
+Direct download
+===============
 Go the `Arm GCC download page`_ and download the "`AArch32 target with soft
 float (arm-linux-gnueabi)`" for 32bit builds and the "`AArch64 GNU/Linux target
 (aarch64-linux-gnu)`" for 64bit builds. When the downloads have finished, you
@@ -37,8 +37,8 @@ Here is an example
     $ mkdir aarch64
     $ tar xf gcc-arm-8.2-2019.01-x86_64-aarch64-linux-gnu.tar.xz -C aarch64 --strip-components=1
 
-2. Using build.git
-==================
+Using build.git
+===============
 As an alternative, you can let :ref:`build`.git download them for you, but this
 of course involves getting a git that you might not otherwise use.
 


### PR DESCRIPTION
minor fixes in `architecture/trusted_applications.rst` and `build/toolchains.rst`.
* Replace `===` underlines with `---` underlines for subsection parts.
* Remove section/subsection numbering.
* Move local references to end of .rst file.