### PR TITLE
Add documentation for DeveloperBox

### DIFF
--- a/building/devices/devbox.rst
+++ b/building/devices/devbox.rst
@@ -1,0 +1,45 @@
+.. _devbox:
+
+############
+DeveloperBox
+############
+
+The instructions here will tell how to build OP-TEE for `DeveloperBox`_.
+
+.. _devbox_build_instructions:
+
+Build instructions
+******************
+
+1. Follow the ":ref:`get_and_build_the_solution`" in :ref:`build`
+   from step 1 to step 3.
+
+2. Initialize EDK2 submodule
+
+    .. code-block:: bash
+        :linenos:
+
+        $ cd <optee-project>/edk2
+        $ git submodule update --init
+
+3. Follow ":ref:`get_and_build_the_solution`" step 4 & 5
+
+4. Stage a new OP-TEE update capsule. This updates TF-A, OP-TEE and UEFI.
+
+    .. code-block:: bash
+        :linenos:
+
+        $ fwupdate --apply {50b94ce5-8b63-4849-8af4-ea479356f0e3} \
+          > <optee-project>/edk2-platforms/Build/DeveloperBox/RELEASE_GCC5/FV/\
+          > SYNQUACERFIRMWAREUPDATECAPSULEFMPPKCS7.Cap
+
+    .. hint::
+
+        Change ``RELEASE_GCC5`` to ``DEBUG_GCC5`` for debug build.
+
+5. Reboot to update.
+
+6. Follow the rest of":ref:`get_and_build_the_solution`" from step 7
+
+
+.. _DeveloperBox: https://www.96boards.org/product/developerbox/

--- a/building/devices/index.rst
+++ b/building/devices/index.rst
@@ -7,6 +7,7 @@ Device specific information
 .. toctree::
     :maxdepth: 1
 
+    devbox
     fvp
     hikey620
     hikey960

--- a/building/gits/build.rst
+++ b/building/gits/build.rst
@@ -93,6 +93,10 @@ related questions etc. Please see the MAINTAINERS_ file for contact information.
       - ``PLATFORM=vexpress-fvp``
       - Yes
 
+    * - `DeveloperBox`_
+      - ``PLATFORM=synquacer``
+      - Yes
+
     * - `HiKey Kirin 620`_
       - ``PLATFORM=hikey``
       - Yes
@@ -149,31 +153,33 @@ gits, then please refer to the next section instead.
 
 .. Please keep this list sorted in alphabetic order:
 
-+----------------+------------------+----------------------+
-| Target         | Manifest xml     | Device documentation |
-+================+==================+======================+
-| AM43xx         | ``am43xx.xml``   | :ref:`ti`            |
-+----------------+------------------+----------------------+
-| AM57xx         | ``am57xx.xml``   | :ref:`ti`            |
-+----------------+------------------+----------------------+
-| ARM Juno board | ``juno.xml``     | :ref:`juno`          |
-+----------------+------------------+----------------------+
-| DRA7xx         | ``dra7xx.xml``   | :ref:`ti`            |
-+----------------+------------------+----------------------+
-| FVP            | ``fvp.xml``      | :ref:`fvp`           |
-+----------------+------------------+----------------------+
-| HiKey 960      | ``hikey960.xml`` | :ref:`hikey960`      |
-+----------------+------------------+----------------------+
-| HiKey          | ``hikey.xml``    | :ref:`hikey`         |
-+----------------+------------------+----------------------+
-| Poplar Debian  | ``poplar.xml``   |                      |
-+----------------+------------------+----------------------+
-| QEMU           | ``default.xml``  | :ref:`qemu_v7`       |
-+----------------+------------------+----------------------+
-| QEMUv8         | ``qemu_v8.xml``  | :ref:`qemu_v8`       |
-+----------------+------------------+----------------------+
-| Raspberry Pi 3 | ``rpi3.xml``     | :ref:`rpi3`          |
-+----------------+------------------+----------------------+
++----------------+-------------------+----------------------+
+| Target         | Manifest xml      | Device documentation |
++================+===================+======================+
+| AM43xx         | ``am43xx.xml``    | :ref:`ti`            |
++----------------+-------------------+----------------------+
+| AM57xx         | ``am57xx.xml``    | :ref:`ti`            |
++----------------+-------------------+----------------------+
+| DeveloperBox   | ``synquacer.xml`` | :ref:`devbox`        |
++----------------+-------------------+----------------------+
+| ARM Juno board | ``juno.xml``      | :ref:`juno`          |
++----------------+-------------------+----------------------+
+| DRA7xx         | ``dra7xx.xml``    | :ref:`ti`            |
++----------------+-------------------+----------------------+
+| FVP            | ``fvp.xml``       | :ref:`fvp`           |
++----------------+-------------------+----------------------+
+| HiKey 960      | ``hikey960.xml``  | :ref:`hikey960`      |
++----------------+-------------------+----------------------+
+| HiKey          | ``hikey.xml``     | :ref:`hikey`         |
++----------------+-------------------+----------------------+
+| Poplar Debian  | ``poplar.xml``    |                      |
++----------------+-------------------+----------------------+
+| QEMU           | ``default.xml``   | :ref:`qemu_v7`       |
++----------------+-------------------+----------------------+
+| QEMUv8         | ``qemu_v8.xml``   | :ref:`qemu_v8`       |
++----------------+-------------------+----------------------+
+| Raspberry Pi 3 | ``rpi3.xml``      | :ref:`rpi3`          |
++----------------+-------------------+----------------------+
 
 Stable releases
 ===============
@@ -460,6 +466,7 @@ don't have to think about anything.
 .. Links to devices etc:
 .. _ARM Juno Board: http://www.arm.com/products/tools/development-boards/versatile-express/juno-arm-development-platform.php
 .. _ARM Foundation FVP: http://www.arm.com/fvp
+.. _DeveloperBox: https://www.96boards.org/product/developerbox
 .. _HiKey Kirin 620: https://www.96boards.org/products/hikey
 .. _HiKey 960: https://www.96boards.org/product/hikey960
 .. _MediaTek MT8173 EVB Board: http://www.mediatek.com/en/products/mobile-communications/tablet/mt8173


### PR DESCRIPTION
This adds a DeveloperBox device-specific document, and updates
build.git and manifest.git support table. 

The manifest for DeveloperBox is pending at [manifest.git PR](https://github.com/OP-TEE/manifest/pull/139). 