### PR TITLE
travis: Force Travis to show failure on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ notifications:
   - email: false
 
 script:
-  - make html
+  - SPHINXOPTS="-W --keep-going" make html

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 #
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SPHINXPROJ    = OP-TEE
 SOURCEDIR     = .


### PR DESCRIPTION
Since I haven't been able to find an equivalent to GCC's "``Wall` `Werror`" when building Sphinx documentation I came up with this, which is a poor mans solution to force a Travis build error when warnings are shown when building the Sphinx documentation. With this, Travis sanity builds will show up with an error in the pull request instead of shown as a successful build (which isn't really correct).

I've done some tests, one where I force an error, then we [get this result](https://travis-ci.org/jbech-linaro/optee_docs/jobs/541649386) and when there are no errors it looks like [this](https://travis-ci.org/jbech-linaro/optee_docs/jobs/541652957).