### PR TITLE
platforms: fix broken link to stm32mp1 external page

### DIFF
--- a/general/platforms.rst
+++ b/general/platforms.rst
@@ -213,7 +213,7 @@ please refer to the file MAINTAINERS_ for contact details for various platforms.
      - No
      - Yes
 
-   * - `STMicroelectronics STM32MP1 series - <http://www.st.com/stm32mp1>`
+   * - `STMicroelectronics STM32MP1 series <http://www.st.com/stm32mp1>`_
      - ``PLATFORM=stm32mp1``
      - Yes
      - Yes


### PR DESCRIPTION
The link to the stm32mp1 was missing the ending underscore, hence the
link wasn't rendered correctly.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>