### PR TITLE
Add ccache and python-pyelftools to prerequisites

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -12,9 +12,9 @@ target you will use in the end.
 .. code-block:: bash
 
     $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
-            automake bc bison build-essential cscope curl device-tree-compiler \
+            automake bc bison build-essential ccache cscope curl device-tree-compiler \
             expect flex ftp-upload gdisk iasl libattr1-dev libc6:i386 libcap-dev \
             libfdt-dev libftdi-dev libglib2.0-dev libhidapi-dev libncurses5-dev \
             libpixman-1-dev libssl-dev libstdc++6:i386 libtool libz1:i386 make \
-            mtools netcat python-crypto python-serial python-wand unzip uuid-dev \
-            xdg-utils xterm xz-utils zlib1g-dev
+            mtools netcat python-crypto python-pyelftools python-serial python-wand \
+            unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev


### PR DESCRIPTION
Adds the packages ccache and python-pyelftools to prerequisites.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>