### PR TITLE
Update ZynqMP documentation

### DIFF
--- a/building/devices/index.rst
+++ b/building/devices/index.rst
@@ -13,6 +13,6 @@ Device specific information
     hikey960
     juno
     qemu
-    zynqmp
     rpi3
     ti
+    zynqmp

--- a/building/devices/zynqmp.rst
+++ b/building/devices/zynqmp.rst
@@ -1,23 +1,46 @@
-.. _zynqmp_zcu102:
+.. _zynqmp:
 
-#######################
-QEMU for ZynqMP zcu102
-#######################
-Instructions below show how to run OP-TEE using QEMU for ZynqMP zcu102 board. 
+#########################
+ZynqMP zcu10x and Ultra96
+#########################
+Instructions below show how to run OP-TEE on ZynqMP zcu10x and Ultra96 board.
+
+Supported boards
+****************
+This makefile supports the following ZynqMP boards:
+	
+	* zcu102
+	* zcu104
+	* zcu106
+	* Ultra96v1
 
 Setting up the toolchain
 ************************
 This build chain heavily relies on Petalinux 2018.2 therefore the first step is 
 to download and install the Petalinux 2018.2 toolchain from the Xilinx website 
-(`Downloads`_). By default, the makefile considers that Petalinux is installed 
-in ``/opt/Xilinx/petalinux_2018_2``. Then, you have to download the zcu102 BSP 
-file from the Xilinx website (`Downloads`_).
+(`Downloads`_). Then, you have to download the needed BSP file from the Xilinx 
+website (`Downloads`_). You may have to create a free Xilinx account to proceed 
+with the two previous steps.
 
-You may have to create a free Xilinx account to proceed with the two previous 
-steps.
+Since OP-TEE 3.6.0, building process relies on `pyelftools`_ and `pycrypto`_ 
+package which are not available in the python distribution provided with 
+Petalinux, you have to manually install it by following steps described 
+hereafter (replace ``/path/to/petalinux`` with the right path):
 
-Configuring and building
-************************
+.. code-block:: bash
+
+	$ sudo apt install python3.5 python3-pip
+
+	$ pip3 install --system --target=/path/to/petalinux/components/yocto/
+	source/aarch64/buildtools/sysroots/x86_64-petalinux-linux/usr/lib/
+	python3.5/site-packages/ pycrypto
+
+	$ pip3 install --system --target=/path/to/petalinux/components/yocto/
+	source/aarch64/buildtools/sysroots/x86_64-petalinux-linux/usr/lib/
+	python3.5/site-packages/ pyelftools
+
+Configuring and building for zcu102 board
+*****************************************
 First, create a new directory which will be used as root directory:
 
 .. code-block:: bash
@@ -38,7 +61,7 @@ Petalinux settings:
 
 	$ git clone https://github.com/OP-TEE/build
 	$ cd ./build
-	$ source /opt/Xilinx/petalinux_2018_2/settings.sh
+	$ source /path/to/petalinux/settings.sh
 
 Finally, use the following commands to create, patch, configure and build the 
 Petalinux project. Petalinux is a powerful but very slow tool, each command may 
@@ -46,12 +69,10 @@ take a while according to the capabilities of your computer.
 
 .. code-block:: bash
 	
-	$ make -f zynqmp.mk petalinux-create
-	$ make -f zynqmp.mk petalinux-config
-	$ make -f zynqmp.mk petalinux-build
+	$ make -f zynqmp.mk
 
-Once the last command ends up you are ready to run QEMU tool. Use the following 
-command:
+Once the last command ends up you are ready to run QEMU tool or to make a 
+bootable SD card. To run QEMU:
 
 .. code-block:: bash
 
@@ -69,22 +90,55 @@ Normal World service and run xtest:
 You can close QEMU session at any time by typing ``Ctrl-A+C`` and entering the 
 ``quit`` command.
 
-QEMU for other ZynqMP boards
-******************************
-This makefile supports other ZynqMP boards:
-	
-	* zcu104
-	* zcu106
-
-To use this makefile with these boards, you have to download corresponding BSP 
-and add option ``PLATFORM=zcu104`` or ``PLATFORM=zcu106`` to each make command.
+Configuring and building for other ZynqMP boards
+*************************************************
+To use this makefile with other supported boards, you have to download the 
+corresponding BSP and add option ``PLATFORM`` to each make command.
 
 .. code-block:: bash
 	 
-	$ make -f zynqmp.mk PLATFORM=zcu=106 petalinux-create
-	$ make -f zynqmp.mk PLATFORM=zcu=106 petalinux-config
-	$ make -f zynqmp.mk PLATFORM=zcu=106 petalinux-build
-	$ make -f zynqmp.mk PLATFORM=zcu=106 qemu
+	$ make -f zynqmp.mk PLATFORM=zcu106
+	$ make -f zynqmp.mk PLATFORM=zcu106 qemu
+
+Hereafter the list of available ``PLATFORM``:
+
+	* ``zcu102``
+	* ``zcu104``
+	* ``zcu106``
+	* ``ultra96-reva``
+
+.. warning::
+
+	On Ultra96 board, UART is not directly available. You have to connect
+	through WIFI Access Point using the procedure detailed here 
+	`Getting started`_.
+
+SD card creation
+****************
+After completion of building process, you can create a bootable SD card. Here,
+we consider that SD card corresponds to ``/dev/sdb``. We will use ``gparted``
+and ``e2image`` tools.
+
+Using ``gparted`` or any other partition manager tool create two partitions on 
+the card:
+
+	* 1GB FAT32 bootable partition (``/dev/sdb1`` hereafter).
+	* EXT4 partition on the remaining memory space (``/dev/sdb2``
+	  hereafter).
+
+Once SD card is partitioned, use the following commands:
+
+.. code-block:: bash
+	 
+	$ cp /path/to/project/images/linux/BOOT.BIN /dev/sdb1
+	$ cp /path/to/project/images/linux/image.ub /dev/sdb1
+	$ sudo e2image -rap /path/to/project/images/linux/rootfs.ext4 /dev/sdb2
+
+Now you can use the newly created SD card to boot your board.
+
+.. note::
+
+	Check that your board is actually configured to boot on the SD card.
 
 Building a given version of OP-TEE
 **********************************
@@ -108,3 +162,6 @@ commands. For additional information, refer to Petalinux Tool Documentation
 
 .. _UG1144: https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_2/ug1144-petalinux-tools-reference-guide.pdf
 .. _Downloads: https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/embedded-design-tools/2018-2.html
+.. _pyelftools: https://pypi.org/project/pyelftools/
+.. _pycrypto: https://pypi.org/project/pycrypto/
+.. _Getting started: https://ultra96-pynq.readthedocs.io/en/latest/getting_started.html


### PR DESCRIPTION
ZynqMP documentation updated to reflect changes introduced by the new support
of Ultra96 boards (see PR https://github.com/OP-TEE/build/pull/380).