### PR TITLE
architecture: update secure boot links

### DIFF
--- a/architecture/secure_boot.rst
+++ b/architecture/secure_boot.rst
@@ -44,7 +44,7 @@ device manufacturers have their own way of doing secure boot. Please reach out
 directly to the manufacturer for the device you are working with to be able to
 understand how to do secure boot on their devices.
 
-.. _auth-framework.rst : https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/auth-framework.rst
+.. _auth-framework.rst : https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/design/auth-framework.rst
 .. _mbed TLS: https://github.com/ARMmbed/mbedtls.git
-.. _user-guide.rst: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/user-guide.rst
-.. _trusted-board-boot.rst: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/trusted-board-boot.rst
+.. _user-guide.rst: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/getting_started/user-guide.rst
+.. _trusted-board-boot.rst: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/design/trusted-board-boot.rst


### PR DESCRIPTION
The TF-A repository restructured its documentation with subfolders,
change the links accordingly.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>