### PR TITLE
Link to QEMU build commands in the FAQ from the "Build an run" page

### DIFF
--- a/building/index.rst
+++ b/building/index.rst
@@ -10,6 +10,8 @@ Since you pressed this, it's likely that you want to know how to build a full
 OP-TEE developer setup. So a first place to start looking is probably at the
 ":ref:`build`" page to get started.
 
+You may also want to look at ":ref:`faq_try_optee`".
+
 .. toctree::
    :maxdepth: 2
 

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -180,6 +180,8 @@ Q: When running `make` from build.git it fails to download the toolchains?
   such an issue, please send the fix as pull request and we will be happy to
   merge it.
 
+.. _faq_try_optee:
+
 Q: What is the quickest and easiest way to try OP-TEE?
 ======================================================
     - That would be running it on QEMU on a local PC. To do that you would need to:


### PR DESCRIPTION
The quick QEMU build instructions are in the FAQ and are not linked from
the "Build and run" page. Therefore they are a bit difficult to find.
This commit adds a link.

Signed-off-by: Jerome Forissier <jerome@forissier.org>