### PR TITLE
toolchain: add llvm/clang instructions

### DIFF
--- a/building/gits/optee_os.rst
+++ b/building/gits/optee_os.rst
@@ -90,6 +90,24 @@ The same for an QEMU Armv8-A (AArch64) would look like this:
 
         $ make V=1
 
+Build using LLVM/clang
+======================
+optee_os can be compiled using llvm/clang. Start by getting the toolchain (see
+:ref:`llvm`). After that you can compile by running.
+
+.. note::
+
+    On line one you need to adjust the path so it matches the version of clang
+    you are using.
+
+.. code-block:: bash
+    :linenos:
+    :emphasize-lines: 1
+
+    $ export PATH=<optee-project>/toolchains/clang-v9.0.1/bin:$PATH
+    $ make COMPILER=clang
+
+
 Coding standards
 ****************
 See :ref:`coding_standards`.

--- a/building/toolchains.rst
+++ b/building/toolchains.rst
@@ -60,4 +60,32 @@ paths and then you are ready to starting compiling OP-TEE components.
 
     $ export PATH=$PATH:$HOME/toolchains/aarch32/bin:$HOME/toolchains/aarch64/bin
 
+.. _llvm:
+
+LLVM / Clang
+************
+It's possible to also compile :ref:`optee_os`.git using llvm/clang. Either get
+the toolchain using your package manager or alternatively build it yourself to
+get the version that you need. To build the llvm toolchain for use in OP-TEE do
+the following.
+
+.. code-block:: bash
+
+    $ sudo apt install ninja-build
+    $ cd /tmp
+    $ git clone https://github.com/llvm/llvm-project.git
+    $ mkdir -p llvm-project/build
+    $ cd llvm-project/build
+    # Check out a version known to be working with OP-TEE
+    $ git checkout llvmorg-9.0.1
+    $ cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_ENABLE_PROJECTS="clang;lld" \
+        -DLLVM_TARGETS_TO_BUILD="AArch64;ARM" \
+        -DCMAKE_INSTALL_PREFIX=<optee-project>/toolchains/clang-v9.0.1 ../llvm
+    $ ninja
+    $ ninja install
+
+Now you'll have a llvm/clang toolchain ready to be used.
+
 .. _Arm GCC download page: https://developer.arm.com/open-source/gnu-toolchain/gnu-a/downloads


### PR DESCRIPTION
Add instructions on how to build optee_os using llvm/clang.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>