### PR TITLE
Remove references to libmpa

### DIFF
--- a/building/gits/optee_os.rst
+++ b/building/gits/optee_os.rst
@@ -184,8 +184,8 @@ building either, because the proper instruction set is selected from the
 ``n``) to select 32-bit.
 
 Architecture-specific source code belongs to sub-directories that follow the
-``arch/$(ARCH)`` pattern, such as: ``core/arch/arm``, ``lib/libmpa/arch/arm``,
-``lib/libutee/arch/arm`` and so on.
+``arch/$(ARCH)`` pattern, such as: ``core/arch/arm``, ``lib/libutee/arch/arm``
+and so on.
 
 CROSS_COMPILE
 -------------
@@ -271,8 +271,7 @@ contains:
 
         - In ``lib/``: ``libutee.a`` (the GlobalPlatform Internal API),
           ``libutils.a`` (which implements a part of the standard C library),
-          and ``libmpa.a`` (which implements multiple precision arithmetic and
-          is required by ``libutee.a``).
+          and other libraries which provide additional APIs.
 
         - In ``include/``: header files for the above libraries
 
@@ -301,12 +300,12 @@ The following variables are defined in ``core/arch/$(ARCH)/$(ARCH).mk``:
     - ``$(core-platform-aflags)``, ``$(core-platform-cflags)`` and
       ``$(core-platform-cppflags)`` are added to the assembler / C compiler /
       preprocessor flags for all source files compiled for TEE Core including
-      the kernel versions of ``libmpa.a`` and ``libutils.a``.
+      the kernel versions of libraries such as ``libutils.a``.
 
     - ``$(ta_arm{32,64}-platform-aflags)``, ``$(ta_arm{32,64}-platform-cflags``)
       and ``$(ta_arm{32,64}-platform-cppflags)`` are added to the assembler / C
       compiler / preprocessor flags when building the user-mode libraries
-      (``libutee.a``, ``libutils.a``, ``libmpa.a``) or Trusted Applications.
+      (``libutee.a``, ``libutils.a``) or Trusted Applications.
 
       The following variables are defined in
       ``core/arch/$(ARCH)/plat-$(PLATFORM)/conf.mk``:

--- a/debug/ftrace.rst
+++ b/debug/ftrace.rst
@@ -22,7 +22,8 @@ Usage
 
     - Build OP-TEE OS and OP-TEE Client with ``CFG_FTRACE_SUPPORT=y``. You
       may also set ``CFG_ULIBS_MCOUNT=y`` in OP-TEE OS to instrument the
-      user TA libraries (libutee, libutils, libmpa).
+      user TA libraries contained in ``optee_os`` (such as ``libutee`` and
+      ``libutils``).
 
     - Optionally build OP-TEE OS with ``CFG_SYSCALL_FTRACE=y`` to dump
       additional syscall function graph information.

--- a/debug/gprof.rst
+++ b/debug/gprof.rst
@@ -14,8 +14,8 @@ Usage
 *****
 
     - Build OP-TEE OS with ``CFG_TA_GPROF_SUPPORT=y``. You may also set
-      ``CFG_ULIBS_MCOUNT=y`` to instrument the user TA libraries (libutee,
-      libutils, libmpa).
+      ``CFG_ULIBS_MCOUNT=y`` to instrument the user TA libraries contained in
+      ``optee_os`` (such as ``libutee`` and ``libutils``).
 
     - Build user TAs with ``-pg``, for instance enable: ``CFG_TA_MCOUNT=y`` to
       instrument whole user TA. Note that instrumented TAs have a larger


### PR DESCRIPTION
libmpa was removed from optee_os so it should not be referenced anymore.

Signed-off-by: Jerome Forissier <jerome@forissier.org>