### PR TITLE
stm32mp1: initial support

### DIFF
--- a/building/devices/index.rst
+++ b/building/devices/index.rst
@@ -14,5 +14,6 @@ Device specific information
     juno
     qemu
     rpi3
+    stm32mp1
     ti
     zynqmp

--- a/building/devices/stm32mp1.rst
+++ b/building/devices/stm32mp1.rst
@@ -1,0 +1,61 @@
+.. _stm32mp1:
+
+########
+STM32MP1
+########
+
+The instructions here will tell how to run OP-TEE on one of the supported
+STM32MP1 boards.
+
+Supported boards
+****************
+
++---------------------+--------------------+------------+-------------------------------+
+| Baord Name          | Manufacturer       | Boot media | Hardware Description          |
++=====================+====================+============+===============================+
+| `STM32MP157A-DK1`_  | STMicroelectronics | SDcard     | `Wiki STM32MP157X-DKX`_       |
++---------------------+--------------------+------------+-------------------------------+
+| `STM32MP157C-DK2`_  | STMicroelectronics | SDcard     | `Wiki STM32MP157X-DKX`_       |
++---------------------+--------------------+------------+-------------------------------+
+| `STM32MP157C-EV1`_  | STMicroelectronics | SDCard     | `Wiki STM32MP157C-EV1`_       |
++---------------------+--------------------+------------+-------------------------------+
+
+Build instructions
+******************
+
+Follow the instructions at ":ref:`get_and_build_the_solution`".
+
+Configuration switch ``PLATFORM`` can be used to specify the target device
+as listed in table below:
+
++------------------------+--------------------------------------+
+| Board Name             | Build configuration directive        |
++========================+======================================+
+| STM32MP157A-DK1        | ``PLATFORM=stm32mp1-157A_DK1``       |
++------------------------+--------------------------------------+
+| STM32MP157C-DK2        | ``PLATFORM=stm32mp1-157C_DK2``       |
++------------------------+--------------------------------------+
+| STM32MP157C-EV1        | ``PLATFORM=stm32mp1-157C_EV1``       |
++------------------------+--------------------------------------+
+
+When the build completes, generated image file sdcard.img can be found
+in the generated binary images directory ``../out/bin/`` from build
+root path. The images is a GPT multipartition image you can raw copy
+to the target SDcard using a tool like dd.
+
+A usual short fecth/build/load shell sequence is like the one below:
+
+.. code-block:: bash
+
+  $ repo init -u https://github.com/OP-TEE/manifest.git -m stm32mp1.xml
+  $ repo sync
+  $ cd build
+  $ make toolchains
+  $ make PLATFORM=stm32mp1-157C_DK2 all
+  $ sudo dd if=../out/bin/sdcard.img of=/dev/sdX conv=fdatasync status=progress
+
+.. _STM32MP157A-DK1: https://www.st.com/en/evaluation-tools/stm32mp157a-dk1.html
+.. _STM32MP157C-DK2: https://www.st.com/en/evaluation-tools/stm32mp157c-dk2.html
+.. _STM32MP157C-EV1: https://www.st.com/en/evaluation-tools/stm32mp157c-ev1.html
+.. _Wiki STM32MP157X-DKX: https://wiki.st.com/stm32mpu/wiki/STM32MP157X-DKX_-_hardware_description
+.. _Wiki STM32MP157C-EV1: https://wiki.st.com/stm32mpu/wiki/STM32MP157C-EV1_-_hardware_description

--- a/building/gits/build.rst
+++ b/building/gits/build.rst
@@ -122,6 +122,18 @@ questions etc. Please see the MAINTAINERS_ file for contact information.
       - ``PLATFORM=rpi3``
       - Yes
 
+    * - `STM32MP157A-DK1`_
+      - ``PLATFORM=stm32mp1-157A_DK1``
+      - Yes
+
+    * - `STM32MP157C-DK2`_
+      - ``PLATFORM=stm32mp1-157C_DK2``
+      - Yes
+
+    * - `STM32MP157C-EV1`_
+      - ``PLATFORM=stm32mp1-157C_EV1``
+      - Yes
+
     * - `Texas Instruments DRA7xx`_
       - ``PLATFORM=ti-dra7xx``
       - Yes
@@ -176,6 +188,8 @@ gits, then please refer to the next section instead.
 | QEMUv8         | ``qemu_v8.xml``   | :ref:`qemu_v8`       |
 +----------------+-------------------+----------------------+
 | Raspberry Pi 3 | ``rpi3.xml``      | :ref:`rpi3`          |
++----------------+-------------------+----------------------+
+| STM32MP1       | ``stm32mp1.xml``  | :ref:`stm32mp1`      |
 +----------------+-------------------+----------------------+
 
 Stable releases
@@ -471,6 +485,9 @@ don't have to think about anything.
 .. _QEMU: http://wiki.qemu.org/Main_Page
 .. _QEMUv8: http://wiki.qemu.org/Main_Page
 .. _Raspberry Pi 3: https://www.raspberrypi.org/products/raspberry-pi-3-model-b
+.. _STM32MP157A-DK1: https://www.st.com/en/evaluation-tools/stm32mp157a-dk1.html
+.. _STM32MP157C-DK2: https://www.st.com/en/evaluation-tools/stm32mp157c-dk2.html
+.. _STM32MP157C-EV1: https://www.st.com/en/evaluation-tools/stm32mp157c-ev1.html
 .. _Texas Instruments DRA7xx: http://www.ti.com/product/DRA746
 .. _Texas Instruments AM57xx: http://www.ti.com/product/AM5728
 .. _Texas Instruments AM43xx: http://www.ti.com/product/AM4379


### PR DESCRIPTION
Describe how to build a bootable image file embedding OP-TEE in some
STM32MP1 base boards, namely STM32MP157C-DK2 and STM32MP157C-EV1.
The documentation provides link to the hardware description of the
boards.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>