### PR TITLE
pseudo TA: clarify what is a pseudo TA

### DIFF
--- a/architecture/trusted_applications.rst
+++ b/architecture/trusted_applications.rst
@@ -13,6 +13,11 @@ cases this is the preferred type of TA to write and use.
 
 Pseudo Trusted Applications
 ***************************
+A Pseudo Trusted Application is not a Trusted Application. A Pseudo TA is not a
+specific entity. A Pseudo TA is an interface. It is an interface exposed by the
+OP-TEE Core to its outer world: to secure client Trusted Applications and to
+non-secure client entities.
+
 These are implemented directly to the OP-TEE core tree in, e.g.,
 ``core/pta`` and are built along with and statically built into the
 OP-TEE core blob.


### PR DESCRIPTION
It seems people get confused in what a pseudo TA is. This change
emphases the nature of pseudo TAs in the documentation: a pseudo
TA is an interface, no more.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>