### PR TITLE
Remove i386 packages from build prerequisites

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -21,9 +21,9 @@ Install the following packages regardless of what target you will use in the end
 
     $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
             automake bc bison build-essential ccache cscope curl device-tree-compiler \
-            expect flex ftp-upload gdisk iasl libattr1-dev libc6:i386 libcap-dev \
+            expect flex ftp-upload gdisk iasl libattr1-dev libcap-dev \
             libfdt-dev libftdi-dev libglib2.0-dev libhidapi-dev libncurses5-dev \
-            libpixman-1-dev libssl-dev libstdc++6:i386 libtool libz1:i386 make \
+            libpixman-1-dev libssl-dev libtool make \
             mtools netcat python-crypto python3-crypto python-pyelftools \
             python3-pycryptodome python3-pyelftools python-serial python3-serial \
             rsync unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev


### PR DESCRIPTION
The i386 packages mentioned in the list of prerequisites for building
OP-TEE are not needed anymore (as far as I can recall, they were used
by older GCC toolchains) and have been obsoleted in the latest Ubuntu
distributions, causing error messages when trying to install.
Therefore, remove them.

Signed-off-by: Jerome Forissier <jerome@forissier.org>