### PR TITLE
index: reorder table of content to start from the prerequisites

### DIFF
--- a/building/index.rst
+++ b/building/index.rst
@@ -15,10 +15,10 @@ You may also want to look at ":ref:`faq_try_optee`".
 .. toctree::
    :maxdepth: 2
 
-   aosp/aosp
+   prerequisites
    devices/index
+   aosp/aosp
    linux/tee_framework
    gits/index
-   prerequisites
    toolchains
    trusted_applications


### PR DESCRIPTION
Reorder table of content to have the follow natural flow:
- prerequisites
- device specific
- AOSP specific
- other articles...

**(edited: move back toolchain articles to "other articles...")**