### PR TITLE
coding standard: defining unsigned integer constants using U()

### DIFF
--- a/general/coding_standards.rst
+++ b/general/coding_standards.rst
@@ -42,6 +42,17 @@ Variables are initialized according to these general guidelines:
       which can be a scalar or a composite type are initialized with
       ``memset()`` in order to minimize the amount of future headache.
 
+Unsigned integer constants are defined using the ``U()``, ``UL()`` or
+``ULL()`` macros, depending on the required width. ``U()`` is a good choice
+for 32-bit values.  Any of the minimum width cousins
+``UINT{8,16,32,64}_C()`` are also accepted for compatibility. This makes
+the sign and size of the integer well defined instead of depend on how
+large the value is or which compiler is used. For example:
+
+.. code-block:: c
+
+    #define MY_UNSIGNED_CONSTANT U(123)
+
 Regarding the checkpatch tool, it is not included directly into this project.
 Please use checkpatch.pl from the Linux kernel git in combination with the local
 `checkpatch script`_.


### PR DESCRIPTION
```
Misra C rule 7.2 says:
"A 'u' or 'U' suffix shall be applied to all integer constants that are
represented in an unsigned type"

Besides Misra this makes sense anyway to make the sign and size of the
integer well defined instead of depending on the size of the constant or
version of C standard a compiler is using.

Do this with the U() macro instead of an explicit 'U' at the end to make
the defines usable from assembly too.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
```

This is a step at trying to align more with Misra C recommendations.
There's quite a few recommendations to contemplate, with some quite intrusive or perhaps even ill suited for OP-TEE. 
But this recommendation (rule 7.2) isn't too bad and a is a good start.

Given how many rules there are we can't list everyone here instead I propose that we expand the guidelines here as needed, with the intent to do so on their own merits. What we write here are the rules we follow. They just happen to also take care of Misra recommendations in the background.