### PR TITLE
stm32mp1: remove sudo command when loading SDcard image

### DIFF
--- a/building/devices/stm32mp1.rst
+++ b/building/devices/stm32mp1.rst
@@ -52,7 +52,7 @@ A usual short fecth/build/load shell sequence is like the one below:
   $ cd build
   $ make toolchains
   $ make PLATFORM=stm32mp1-157C_DK2 all
-  $ sudo dd if=../out/bin/sdcard.img of=/dev/sdX conv=fdatasync status=progress
+  $ dd if=../out/bin/sdcard.img of=/dev/sdX conv=fdatasync status=progress
 
 .. _STM32MP157A-DK1: https://www.st.com/en/evaluation-tools/stm32mp157a-dk1.html
 .. _STM32MP157C-DK2: https://www.st.com/en/evaluation-tools/stm32mp157c-dk2.html


### PR DESCRIPTION
Remove the sudo command from the shell instruction . When things
can be made without sudo admin rights, it is really preferred to
use standard rights hence not recommending this in this documentation.

The fact is it may not be necessary to use sudo right to update
an SDcard device on a host, depending on the host configuration.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>