### PR TITLE
[prerequisites] add note about <= ubuntu 18.04

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -33,3 +33,9 @@ For older versions, you might need to pull `pycryptodome` as a pip package:
 .. code-block:: bash
 
     $ python3 -m pip install --user pycryptodome
+
+For <= ubuntu 18.04 distribution, you might need to remove python3-pycryptodome:
+
+.. code-block:: bash
+
+    $ sudo apt-get remove python3-pycryptodome


### PR DESCRIPTION
1) ubuntu 18.04: apt install python3-pycryptodome == 3.4.7 as
pycryptodomex on ubuntu and has the highest priority to be `import`.

2) The pycryptodomex 3.4.7 is not supported by sign_encrypt.py.

3) Need to remove python3-pycryptodome and install the newest
pycryptodome by pip install tool.