### PR TITLE
Add NXP security disclaimer

### DIFF
--- a/architecture/index.rst
+++ b/architecture/index.rst
@@ -16,3 +16,4 @@ Architecture
    trusted_applications
    virtualization
    spmc
+   platforms/index

--- a/architecture/platforms/index.rst
+++ b/architecture/platforms/index.rst
@@ -6,3 +6,5 @@ Platform documentation
 
 .. toctree::
     :maxdepth: 1
+
+    nxp

--- a/architecture/platforms/index.rst
+++ b/architecture/platforms/index.rst
@@ -1,0 +1,8 @@
+.. _platform_documentation:
+
+######################
+Platform documentation
+######################
+
+.. toctree::
+    :maxdepth: 1

--- a/architecture/platforms/nxp.rst
+++ b/architecture/platforms/nxp.rst
@@ -1,0 +1,40 @@
+.. _nxp:
+
+###
+NXP
+###
+
+.. _security_disclaimer:
+
+Security Disclaimer
+*******************
+	- NXP i.MX processors have various security-relevant modules that may
+	  be configured by the customer to effectively secure the device.
+	- These security modules vary by the i.MX product family and may include:
+		- The **Central Security Unit (CSU)** that manages the system security
+		  policy for peripheral access on the SoC.
+		- The **Resource Domain Controllers (RDC/XRDC/TRDC)** that provide
+		  support for the isolation of peripherals and memory.
+		- **Arm® TrustZone®** technology-based memory protection for embedded
+		  memories such as the on-chip RAM (OCRAM).
+		- The **TrustZone ® Address Space Controller (TZASC)** that protects and
+		  secures data in a trusted execution environment.
+		- The **AIPSTZ** bridge that provides programmable access protections
+		  for both controllers and peripherals.
+	- The default security configuration in OP-TEE OS for these security modules
+	  is left in an open (non-secure) state because a universal secure
+	  configuration that meets all customer requirements is not possible.
+	- NXP delivers various open-source software components (NXP OP-TEE OS) for
+	  customer enablement, however, these are not provided as secure
+	  production-ready implementations.
+	- Using OP-TEE OS upstream releases instead of NXP OPTEE-OS releases may
+	  have an impact on the features supported and the security level of the
+	  i.MX platforms.
+	- Customers should optimize the security configuration in OP-TEE OS to lock
+	  and secure end products according to their specific security requirements.
+	- NXP has documented how to securely configure these security modules in the
+	  respective `i.MX SoC Reference and Security manuals <https://www.nxp.com/products/processors-and-microcontrollers/arm-processors/i-mx-applications-processors:IMX_HOME>`_
+	  and also provides a Security Checklist for the i.MX family to help
+	  customers secure end products.
+	- For Further assistance please contact your NXP field representative or
+	  submit an `NXP Support ticket <https://support.nxp.com/>`_.

--- a/architecture/porting_guidelines.rst
+++ b/architecture/porting_guidelines.rst
@@ -411,7 +411,7 @@ product. There are a couple of reasons for that.
 
 Because of this we always urge companies and device manufacturers making the end
 product to follow the security guidelines from the chipmaker they are basing
-their products on.
+their products on. Refer also to :ref:`platform_documentation`
 
 
 .. _core/arch/arm/plat-hikey/conf.mk: https://github.com/OP-TEE/optee_os/blob/master/core/arch/arm/plat-hikey/conf.mk


### PR DESCRIPTION
Hello @jbech-linaro @ruchi393 @jenswi-linaro @jforissier 

In this pull-request:

- I added a dedicated space for platform specific documentation. Please let me know if you have a something else in mind regarding the doc structure.
- I added the NXP security disclaimer to the NXP page.

Note: I had to force `docutils<0.18` in `requirements.txt` because of this issue : https://github.com/readthedocs/readthedocs.org/issues/8618. Let me know if you want me to merge this (temporary) fix.

Thanks!
Clement
