### PR TITLE
building: prerequisite: add libcap-ng-dev

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -21,8 +21,8 @@ Install the following packages regardless of what target you will use in the end
 
     $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
             automake bc bison build-essential ccache codespell \
-            cscope curl device-tree-compiler \
-            expect flex ftp-upload gdisk iasl libattr1-dev libcap-dev \
+            cscope curl device-tree-compiler expect flex ftp-upload gdisk iasl \
+            libattr1-dev libcap-dev libcap-ng-dev \
             libfdt-dev libftdi-dev libglib2.0-dev libgmp-dev libhidapi-dev \
             libmpc-dev libncurses5-dev libpixman-1-dev libssl-dev libtool make \
             mtools netcat ninja-build python-crypto python3-crypto python-pyelftools \


### PR DESCRIPTION
Building Qemu with VirtFS feature enables requires libcap-ng-devel as
prerequisite for build to be successful otherwise following error is
seen on Ubuntu 20.04:

../meson.build:1075:6: ERROR: Problem encountered: virtio-9p (virtfs) requires libcap-ng-devel and libattr-devel

Fix this via adding corresponding prerequisite.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>