### PR TITLE
faq: Add a question for building GCC with BTI

### DIFF
--- a/architecture/arm_security_extensions.rst
+++ b/architecture/arm_security_extensions.rst
@@ -34,12 +34,14 @@ is looking for ways of providing users easy access to BTI-enabled libraries.
 In the short-term, they plan to create documentation to make it easier for users to
 build BTI-enabled libraries themselves. Longer-term, they will begin discussions
 on how to ensure BTI-enabled libraries are available automatically to users.
-Please contact GCC team for more information on same.
+Please contact GCC team for more information on same. In the meantime, building a
+BTI-enabled GCC toolchain is possible as decribed in :ref:`faq_gcc_bti`.
 
 The same problem is also there with clang toolchain. So, when using clang to build
 OP-TEE with ``CFG_CORE_BTI=y``, builtins (found in llvm's "compiler-rt"
 project) must be built with BTI protection enabled. We have some instructions on
-how to build the compiler-rt with BTI enabled. These are available in FAQ.
+how to build the compiler-rt with BTI enabled. These are available in
+:ref:`faq_llvm_bti`.
 
 
 How to enable BTI for TA's

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -178,6 +178,8 @@ Q: When running `make` from build.git it fails to download the toolchains?
   such an issue, please send the fix as pull request and we will be happy to
   merge it.
 
+.. _faq_llvm_bti:
+
 Q: How can I build LLVM compiler-rt with BTI enabled ?
 ======================================================
      - Download the llvm-12 sources either from the releases page or you can
@@ -233,6 +235,35 @@ Q: How can I build LLVM compiler-rt with BTI enabled ?
        How you take this set of libraries and integrate it into your overall
        build system is up to you. The major thing to note is that the name of
        the library does not change when you enable BTI protection
+
+.. _faq_gcc_bti:
+
+Q: How can I build GCC with BTI enabled?
+========================================
+     - A GCC toolchain with BTI enabled can easily be built using Crosstool-NG:
+
+       .. code-block:: bash
+
+           $ git clone https://github.com/crosstool-ng/crosstool-ng
+           $ cd crosstool-ng
+           $ ./bootstrap && ./configure --enable-local && make
+           $ ./ct-ng aarch64-unknown-linux-gnu
+           $ cat >>.config <<_EOF_
+           CT_CC_GCC_EXTRA_CONFIG_ARRAY="--enable-standard-branch-protection"
+           CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--enable-standard-branch-protection"
+           _EOF_
+           $ ./ct-ng build.$(nproc)
+
+       The above commands will install the new toolchain in
+       ``~/x-tools/aarch64-unknown-linux-gnu``. You can then use this toolchain
+       to build and run OP-TEE for :ref:`qemu_v8` with full BTI support by adding
+       a few arguments to the ``make run`` command:
+
+       .. code-block:: bash
+
+           $ make CFG_CORE_BTI=y CFG_TA_BTI=y CFG_USER_TA_TARGETS=ta_arm64 \
+             AARCH64_CROSS_COMPILE=~/x-tools/aarch64-unknown-linux-gnu/bin/aarch64-linux-gnu- \
+             run
 
 .. _faq_try_optee:
 


### PR DESCRIPTION
Explain how to easily build a GCC toolchain compatible with OP-TEE's
CFG_CORE_BTI=y/CFG_TA_BTI=y.

Signed-off-by: Jerome Forissier <jerome@forissier.org>