### PR TITLE
platform: add AMD/Xilinx Versal ACAP

### DIFF
--- a/general/platforms.rst
+++ b/general/platforms.rst
@@ -273,6 +273,11 @@ please refer to the file MAINTAINERS_ for contact details for various platforms.
      - Yes
      - Yes
 
+   * - `AMD/Xilinx Versal ACAP <https://www.xilinx.com/products/silicon-devices/acap/versal.html>`_
+     - ``PLATFORM=versal``
+     - Yes
+     - Yes
+       
    * - `Xilinx Zynq 7000 ZC702 <http://www.xilinx.com/products/boards-and-kits/ek-z7-zc702-g.html>`_
      - ``PLATFORM=zynq7k-zc702``
      - Yes


### PR DESCRIPTION
Add the AMD/Xilinx Versal Adaptive Compute Acceleration Platform

Reference board:
 https://www.xilinx.com/products/boards-and-kits/vck190.html

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>