### PR TITLE
building: prerequisite: add libslirp-dev

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -41,6 +41,7 @@ available.
               libmpc-dev \
               libncurses5-dev \
               libpixman-1-dev \
+              libslirp-dev \
               libssl-dev \
               libtool \
               make \


### PR DESCRIPTION
Adds libslirp-dev (needed by QEMU 7.1+) to prerequisite host package list.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>