### PR TITLE
docs: add 'swig' to the Ubuntu 22.04 prerequisites

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -56,6 +56,7 @@ available.
               python3-serial \
               python-is-python3 \
               rsync \
+              swig \
               unzip \
               uuid-dev \
               xdg-utils \


### PR DESCRIPTION
When building for RockPi4 using Ubuntu 22.04 we need to have the host package 'swig' installed as well.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>