### PR TITLE
fix readthedocs build warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  apt_packages:
+  - plantuml
+  - graphviz
 
 # Other variants to build than HTML
 formats:


### PR DESCRIPTION
readthedocs build have some warning:

- WARNING: plantuml command 'plantuml' cannot be run
- WARNING: dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting

Which means the build system losing the `plantuml` and `graphviz` packages.

Acroording to the [build-apt-packages](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-apt-packages), we could install some package using the apt.
So, just add the `plantuml` and `graphviz`, readthedocs can build the `uml` succesfully.

The fixed doc with `uml` could see [here](https://optee-docs-test.readthedocs.io/en/latest/architecture/core.html#id11).