### PR TITLE
building: qemu: update fetch/build/run command example

### DIFF
--- a/building/devices/qemu.rst
+++ b/building/devices/qemu.rst
@@ -19,12 +19,12 @@ for Armv7-A is like the one below:
 
 .. code-block:: bash
 
+  $ mkdir optee
+  $ cd optee
   $ repo init -u https://github.com/OP-TEE/manifest.git
   $ repo sync
   $ cd build
   $ make toolchains
-  # Note that if you wish to debug optee-os or a TA, you should disable ASLR
-  # with flag "CFG_CORE_ASLR=n"
   $ make run
 
 .. hint::
@@ -251,12 +251,12 @@ for Armv8-A is like the one below:
 
 .. code-block:: bash
 
+  $ mkdir optee
+  $ cd optee
   $ repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml
   $ repo sync
   $ cd build
   $ make toolchains
-  # Note that if you wish to debug optee-os or a TA, you should disable ASLR
-  # with flag "CFG_CORE_ASLR=n"
   $ make run
 
 All other things (networking, GDB etc) in the v7 section above is also


### PR DESCRIPTION
The repo command fetches code in the current directory so it is best to run it inside a directory created specifically for that purpose.

The mentions about disabling ASLR are not exact (TA ASLR has its own config flag) and are not very relevant to the short descriptions so remove them.