### PR TITLE
building: prerequisite: Install cryptography by pip on Ubuntu 20.04

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -103,7 +103,6 @@ available.
               netcat \
               ninja-build \
               python3-crypto \
-              python3-cryptography \
               python3-pip \
               python3-pyelftools \
               python3-serial \
@@ -114,6 +113,8 @@ available.
               xterm \
               xz-utils \
               zlib1g-dev
+
+            $ pip3 install cryptography
 
 
     .. tab:: Older


### PR DESCRIPTION
The cryptography python package in Ubuntu 20.04 is too old for new OP-TEE releases. Using pip to install a new version cryptography should be used to avoid build errors.