### PR TITLE
Add a few missing packages to Ubuntu 20.04 prerequisites for QEMUv8

### DIFF
--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -22,6 +22,7 @@ available.
               bc \
               bison \
               build-essential \
+              cpio \
               ccache \
               cscope \
               curl \
@@ -32,6 +33,7 @@ available.
               flex \
               ftp-upload \
               gdisk \
+              git \
               libattr1-dev \
               libcap-dev \
               libfdt-dev \
@@ -59,6 +61,7 @@ available.
               swig \
               unzip \
               uuid-dev \
+              wget \
               xdg-utils \
               xterm \
               xz-utils \

--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -78,6 +78,7 @@ available.
               bison \
               build-essential \
               ccache \
+              cpio \
               cscope \
               curl \
               device-tree-compiler \
@@ -85,6 +86,7 @@ available.
               flex \
               ftp-upload \
               gdisk \
+              git \
               iasl \
               libattr1-dev \
               libcap-dev \
@@ -96,12 +98,14 @@ available.
               libmpc-dev \
               libncurses5-dev \
               libpixman-1-dev \
+              libslirp-dev \
               libssl-dev \
               libtool \
               make \
               mtools \
               netcat \
               ninja-build \
+              python-is-python3 \
               python3-crypto \
               python3-cryptography \
               python3-pip \
@@ -110,6 +114,7 @@ available.
               rsync \
               unzip \
               uuid-dev \
+              wget \
               xdg-utils \
               xterm \
               xz-utils \


### PR DESCRIPTION
A few packages are missing from the Ubuntu 20.04 prerequisites in order to be able to build OP-TEE for QEMUv8. Add them.