### PR TITLE
building: prerequisites: provide Dockerfiles

### DIFF
--- a/building/Dockerfile.Ubuntu-20.04
+++ b/building/Dockerfile.Ubuntu-20.04
@@ -1,0 +1,60 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt upgrade -y
+RUN apt install -y \
+    android-tools-adb \
+    android-tools-fastboot \
+    autoconf \
+    automake \
+    bc \
+    bison \
+    build-essential \
+    ccache \
+    cpio \
+    cscope \
+    curl \
+    device-tree-compiler \
+    expect \
+    flex \
+    ftp-upload \
+    gdisk \
+    git \
+    iasl \
+    libattr1-dev \
+    libcap-dev \
+    libfdt-dev \
+    libftdi-dev \
+    libglib2.0-dev \
+    libgmp3-dev \
+    libhidapi-dev \
+    libmpc-dev \
+    libncurses5-dev \
+    libpixman-1-dev \
+    libslirp-dev \
+    libssl-dev \
+    libtool \
+    make \
+    mtools \
+    netcat \
+    ninja-build \
+    python-is-python3 \
+    python3-crypto \
+    python3-cryptography \
+    python3-pip \
+    python3-pyelftools \
+    python3-serial \
+    rsync \
+    unzip \
+    uuid-dev \
+    wget \
+    xdg-utils \
+    xterm \
+    xz-utils \
+    zlib1g-dev
+RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo && chmod a+x /bin/repo
+RUN mkdir /optee
+WORKDIR /optee
+RUN repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml && repo sync -j10
+WORKDIR /optee/build
+RUN make -j2 toolchains
+RUN make -j$(nproc) check

--- a/building/Dockerfile.Ubuntu-22.04
+++ b/building/Dockerfile.Ubuntu-22.04
@@ -1,0 +1,62 @@
+FROM ubuntu:22.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt upgrade -y
+RUN apt install -y \
+    adb \
+    acpica-tools \
+    autoconf \
+    automake \
+    bc \
+    bison \
+    build-essential \
+    ccache \
+    cpio \
+    cscope \
+    curl \
+    device-tree-compiler \
+    e2tools \
+    expect \
+    fastboot \
+    flex \
+    ftp-upload \
+    gdisk \
+    git \
+    libattr1-dev \
+    libcap-dev \
+    libfdt-dev \
+    libftdi-dev \
+    libglib2.0-dev \
+    libgmp3-dev \
+    libhidapi-dev \
+    libmpc-dev \
+    libncurses5-dev \
+    libpixman-1-dev \
+    libslirp-dev \
+    libssl-dev \
+    libtool \
+    libusb-1.0-0-dev \
+    make \
+    mtools \
+    netcat \
+    ninja-build \
+    python3-cryptography \
+    python3-pip \
+    python3-pyelftools \
+    python3-serial \
+    python-is-python3 \
+    rsync \
+    swig \
+    unzip \
+    uuid-dev \
+    wget \
+    xdg-utils \
+    xterm \
+    xz-utils \
+    zlib1g-dev
+RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo && chmod a+x /bin/repo
+RUN mkdir /optee
+WORKDIR /optee
+RUN repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml && repo sync -j10
+WORKDIR /optee/build
+RUN make -j2 toolchains
+RUN make -j$(nproc) check

--- a/building/prerequisites.rst
+++ b/building/prerequisites.rst
@@ -6,115 +6,19 @@ Prerequisites
 We believe that you can use any Linux distribution to build OP-TEE, but as
 maintainers of OP-TEE we are mainly using Ubuntu-based distributions and to be
 able to build and run OP-TEE there are a few packages that needs to be
-available.
+available. Hereafter we provide Docker files which may be used as a reference.
 
 .. tabs::
 
     .. tab:: Ubuntu 22.04
 
-        .. code-block:: bash
-
-            $ sudo apt install \
-              adb \
-              acpica-tools \
-              autoconf \
-              automake \
-              bc \
-              bison \
-              build-essential \
-              ccache \
-              cscope \
-              curl \
-              device-tree-compiler \
-              e2tools \
-              expect \
-              fastboot \
-              flex \
-              ftp-upload \
-              gdisk \
-              libattr1-dev \
-              libcap-dev \
-              libfdt-dev \
-              libftdi-dev \
-              libglib2.0-dev \
-              libgmp3-dev \
-              libhidapi-dev \
-              libmpc-dev \
-              libncurses5-dev \
-              libpixman-1-dev \
-              libslirp-dev \
-              libssl-dev \
-              libtool \
-              libusb-1.0-0-dev \
-              make \
-              mtools \
-              netcat \
-              ninja-build \
-              python3-cryptography \
-              python3-pip \
-              python3-pyelftools \
-              python3-serial \
-              python-is-python3 \
-              rsync \
-              swig \
-              unzip \
-              uuid-dev \
-              xdg-utils \
-              xterm \
-              xz-utils \
-              zlib1g-dev
-
+        .. include:: Dockerfile.Ubuntu-22.04
+           :code: text
 
     .. tab:: Ubuntu 20.04
 
-        .. code-block:: bash
-
-            $ sudo apt install \
-              android-tools-adb \
-              android-tools-fastboot \
-              autoconf \
-              automake \
-              bc \
-              bison \
-              build-essential \
-              ccache \
-              cscope \
-              curl \
-              device-tree-compiler \
-              expect \
-              flex \
-              ftp-upload \
-              gdisk \
-              iasl \
-              libattr1-dev \
-              libcap-dev \
-              libfdt-dev \
-              libftdi-dev \
-              libglib2.0-dev \
-              libgmp3-dev \
-              libhidapi-dev \
-              libmpc-dev \
-              libncurses5-dev \
-              libpixman-1-dev \
-              libssl-dev \
-              libtool \
-              make \
-              mtools \
-              netcat \
-              ninja-build \
-              python3-crypto \
-              python3-cryptography \
-              python3-pip \
-              python3-pyelftools \
-              python3-serial \
-              rsync \
-              unzip \
-              uuid-dev \
-              xdg-utils \
-              xterm \
-              xz-utils \
-              zlib1g-dev
-
+        .. include:: Dockerfile.Ubuntu-20.04
+           :code: text
 
     .. tab:: Older
 


### PR DESCRIPTION
Instead of providing the list of required packages as an apt command, give a full Dockerfile. The advantage being, it can be used directly to build and therefore make sure the list is still up to date. For example:

 $ cd building
 $ docker build --no-cache -f Dockerfile.Ubuntu-22.04 .