### PR TITLE
stm32mp1: fix the Get and build the solution link

### DIFF
--- a/building/devices/stm32mp1.rst
+++ b/building/devices/stm32mp1.rst
@@ -35,7 +35,7 @@ booting from the SDcard slot.
 Build instructions
 ******************
 
-Follow the instructions at "get_and_build_the_solution".
+Follow the instructions at ":ref:`get_and_build_the_solution`".
 
 Configuration switch ``PLATFORM`` can be used to specify the target device
 as listed in table below:


### PR DESCRIPTION
Fix the missing link to the "Get and build the solution" page in the STM32MP1 device documentation.