### PR TITLE
building: standalonemm: Fix typo for StandAloneMM

### DIFF
--- a/building/efi_vars/stmm.rst
+++ b/building/efi_vars/stmm.rst
@@ -4,9 +4,9 @@
 StandAloneMM
 ############
 
-StandAlomeMM is a PE/COFF binary produced by EDK2. For Arm platforms we 
+StandAloneMM is a PE/COFF binary produced by EDK2. For Arm platforms we 
 can compile and use it, in combination with OP-TEE to store EFI variables
-in and RPMB partition of our eMMC.
+in an RPMB partition of our eMMC.
 
 EDK2 Build instructions
 ***********************


### PR DESCRIPTION
Hi,

I found a typo in the doc, I think it should be `StandAloneMM` instead of `StandAlomeMM`