### PR TITLE
building: prerequisites: fix Ubuntu Dockerfiles

### DIFF
--- a/building/Dockerfile.Ubuntu-20.04
+++ b/building/Dockerfile.Ubuntu-20.04
@@ -21,7 +21,7 @@ RUN apt install -y \
     git \
     iasl \
     libattr1-dev \
-    libcap-dev \
+    libcap-ng-dev \
     libfdt-dev \
     libftdi-dev \
     libglib2.0-dev \

--- a/building/Dockerfile.Ubuntu-22.04
+++ b/building/Dockerfile.Ubuntu-22.04
@@ -22,7 +22,7 @@ RUN apt install -y \
     gdisk \
     git \
     libattr1-dev \
-    libcap-dev \
+    libcap-ng-dev \
     libfdt-dev \
     libftdi-dev \
     libglib2.0-dev \


### PR DESCRIPTION
When building on Ubuntu 20.04 or 22.04, libcap-ng-dev is needed, not libcap-dev. Without the latter, the QEMU build fails when "make XEN_BOOT=y" is invoked.