### PR TITLE
Fix ftrace_format.py not reading from stdin

### DIFF
--- a/debug/ftrace.rst
+++ b/debug/ftrace.rst
@@ -50,7 +50,7 @@ Usage
     - Run helper scripts called ``ftrace_format.py`` to translate the function
       graph binary data into human readable text and ``symbolize.py`` to
       convert function addresses into function names:
-      ``cat ftrace-<ta_uuid>.out | optee_os/scripts/ftrace_format.py |
+      ``optee_os/scripts/ftrace_format.py ftrace-<ta_uuid>.out |
       optee_os/scripts/symbolize.py -d <ta_uuid>.elf -d tee.elf``
 
     - Refer to `commit 5c2c0fb31efb`_ for a full usage example on QEMU.


### PR DESCRIPTION
`optee_os/scripts/ftrace_format.py` does not read from `stdin`, hence piping the output of `cat` into it does not work and only prints usage information:

```
Usage: optee_os/scripts/ftrace_format.py ftrace.out
Converts a ftrace file to text. Output is written to stdout.
```
Instead, the `ftrace-<ta_uuid>.out` file has to be given as an argument like shown in the example in [5c2c0fb31efb](https://github.com/OP-TEE/optee_os/commit/5c2c0fb31efb).
```
optee_os/scripts/ftrace_format.py ftrace-<ta_uuid>.out  | optee_os/scripts/symbolize.py -d <ta_uuid>.elf -d tee.elf
```