### PR TITLE
build: add --partial-clone when using --reference

### DIFF
--- a/building/gits/build.rst
+++ b/building/gits/build.rst
@@ -424,9 +424,9 @@ instead of 15-30 minutes. The way to do this are as follows.
 
        .. code-block:: bash
 
-        $ repo init -u https://github.com/OP-TEE/manifest.git --reference $HOME/devel/optee-ref
+        $ repo init -u https://github.com/OP-TEE/manifest.git --partial-clone --reference $HOME/devel/optee-ref
 
-    4. The rest is the same above, but now it will only take a couple of seconds
+    4. The rest is the same above, but now it will only take less than a minute
        to clone a forest.
 
 Normally '1' and '2' above is something you will only do once. Also if you


### PR DESCRIPTION
Over the years, there has unfortunately been some slowdown when using the repo reference command. We reported this issue [1] and for some time we temporarily checked out an earlier commit as a workaround. However, Google seemed to improved it again in later versions and although slower, it was acceptable.

However, we've noticed that things are running slower yet again. After some trail and error, we've concluded that adding the "--partial-clone" when running the "repo init" command together with "--reference" brings down the sync time to less than a minute again. Therefore from now on we recommend using that when using reference mirrors.

Link: https://issues.gerritcodereview.com/issues/40014651?pli=1 [1]