### PR TITLE
config: Upgrade Sphinx and dependencies

### DIFF
--- a/architecture/spmc.rst
+++ b/architecture/spmc.rst
@@ -286,10 +286,10 @@ access to the Normal World buffers.
 FF-A compliance
 ===============
 
-.. |ffa_fs| replace:: :opticon:`check-circle-fill`
-.. |ffa_ps| replace:: :opticon:`check-circle`
-.. |ffa_ns| replace:: :opticon:`x`
-.. |ffa_na| replace:: :opticon:`horizontal-rule`
+.. |ffa_fs| replace:: :octicon:`check-circle-fill`
+.. |ffa_ps| replace:: :octicon:`check-circle`
+.. |ffa_ns| replace:: :octicon:`x`
+.. |ffa_na| replace:: :octicon:`horizontal-rule`
 
 Legend
 ------

--- a/conf.py
+++ b/conf.py
@@ -42,7 +42,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinx.ext.graphviz',
-    'sphinx_panels',
+    'sphinx_design',
     'sphinxcontrib.plantuml',
     'sphinx_tabs.tabs',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-sphinx-rtd-theme
-sphinxcontrib-plantuml==0.24
-Pillow==9.3.0
-sphinx-tabs
-sphinx-panels==0.6.0
-sphinx==4.5.0
+pillow==10.2.0 
+Sphinx==7.2.6
+sphinxcontrib-plantuml==0.27
+sphinx_design==0.5.0
+sphinx-rtd-theme==2.0.0
+sphinx-tabs==3.4.4


### PR DESCRIPTION
ReadtheDocs now require at least version 5.0 of Sphinx. We've been using 4.5.0 and therefore we needed to upgrade to a more recent version.

Sphinx:
- Upgrade Sphinx to v7.2.6.
- Upgrade all packages and modules needed to the most recent versions as of today.
- Replace 'sphinx_panels' (deprecated) with 'sphinx_design'.
- Sort the packages and modules alphabetically in the requirements.txt file.

Errors:
- When doing the upgrade we got multiple errors from the SPMC pages, it looks like the way to refer to an icon has been changed from 'opticon' to 'octicon'. To avoid the error when upgrading, fix this in the same commit.