### PR TITLE
crypto: reference to FIPS 140-2 certification

### DIFF
--- a/architecture/crypto.rst
+++ b/architecture/crypto.rst
@@ -191,6 +191,20 @@ GP requirements tested and covered by the OP-TEE sanity test suite
 supported - i.e: the SE05x does not implement all RSA key sizes - we opted for
 disabling those particular tests at build time rather than letting them fail.
 
+Some cryptographic co-processors may have limitations regarding the
+range of key sizes and supported ciphers. For instance, the AMD/Xilinx
+Versal ACAP Cryptographic driver may have constraints on key sizes,
+while NXP SE5X HSM modules may lack support for RSA or ECC. In such
+cases, especially when dealing with unsupported key sizes, it may be
+necessary to resort to a software implementation of the cipher,
+typically utilizing LibTomCrypt.
+
+.. note::
+    While the Hardware Security Modules or Cryptographic hardware
+    processors supported by OP-TEE may achieve FIPS 140-2 certification
+    at level 3, the software implementations of certain algorithms that
+    OP-TEE may fallback to cannot attain certification beyond level 2.
+
 NXP SE05X Family of Secure Elements
 ***********************************
 

--- a/architecture/crypto.rst
+++ b/architecture/crypto.rst
@@ -67,11 +67,11 @@ default implementation, mostly based on LibTomCrypt_, is as follows:
 
 .. code-block:: c
     :caption: File: core/crypto/crypto.c
-    
+
     /*
      * Default implementation for all functions in crypto.h
      */
-    
+
     #if !defined(_CFG_CRYPTO_WITH_HASH)
     TEE_Result crypto_hash_get_ctx_size(uint32_t algo __unused,
                                         size_t *size __unused)
@@ -80,19 +80,19 @@ default implementation, mostly based on LibTomCrypt_, is as follows:
     }
     ...
     #endif /*_CFG_CRYPTO_WITH_HASH*/
-    
+
 .. code-block:: c
     :caption: File: core/lib/libtomcrypt/tee_ltc_provider.c
-    
+
     #if defined(_CFG_CRYPTO_WITH_HASH)
     TEE_Result crypto_hash_get_ctx_size(uint32_t algo, size_t *size)
     {
     	/* ... */
     	return TEE_SUCCESS;
     }
-    
+
     #endif /*_CFG_CRYPTO_WITH_HASH*/
-    
+
 As shown above, families of algorithms can be disabled and crypto.c_ will
 provide default null implementations that will return
 ``TEE_ERROR_NOT_IMPLEMENTED``.


### PR DESCRIPTION
When using FIPS 140-2 certified cryptographip devices, the fact that operating on some unsupported key sizes might fallback to the cipher's software implementation will cause a degradation in the cipher's security level.

Create a note to higlight this fact.