### PR TITLE
Fix broken links to auth-framework.rst

### DIFF
--- a/architecture/porting_guidelines.rst
+++ b/architecture/porting_guidelines.rst
@@ -431,7 +431,7 @@ their products on. Refer also to :ref:`platform_documentation`
 .. _core/include/kernel/tee_common_otp.h: https://github.com/OP-TEE/optee_os/blob/master/core/include/kernel/tee_common_otp.h
 
 
-.. _auth-framework.rst: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/auth-framework.rst
+.. _auth-framework.rst: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/design/auth-framework.rst
 .. _HSM: https://en.wikipedia.org/wiki/Hardware_security_module
 .. _MAINTAINERS.md: https://github.com/OP-TEE/optee_os/blob/master/MAINTAINERS
 .. _OTP: https://en.wikipedia.org/wiki/Programmable_read-only_memory

--- a/building/devices/rpi3.rst
+++ b/building/devices/rpi3.rst
@@ -674,7 +674,7 @@ And shortly thereafter you will see GDB stops on your breakpoint and from there
 you can debug using normal GDB commands.
 
 
-.. _`Authentication Framework`: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/auth-framework.rst
+.. _`Authentication Framework`: https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/design/auth-framework.rst
 .. _Bus Blaster: http://dangerousprototypes.com/docs/Bus_Blaster
 .. _core team: https://github.com/orgs/OP-TEE/teams/linaro/members
 .. _eBay: https://www.ebay.com/sch/i.html?&_nkw=UART+cable


### PR DESCRIPTION
The file has been moved to a `design` subdirectory. Update the path in two places.