### PR TITLE
prereqs/ubuntu-22.04: Add Xalan to build prerequisites

### DIFF
--- a/building/Dockerfile.Ubuntu-22.04
+++ b/building/Dockerfile.Ubuntu-22.04
@@ -49,6 +49,7 @@ RUN apt install -y \
     unzip \
     uuid-dev \
     wget \
+    xalan \
     xdg-utils \
     xterm \
     xz-utils \


### PR DESCRIPTION
The GlobalPlatform extended test suite requires Xalan. Add it to the Ubuntu 22.04 build prerequisites.