### PR TITLE
ta: add warning about TA parameter checking

### DIFF
--- a/building/trusted_applications.rst
+++ b/building/trusted_applications.rst
@@ -323,12 +323,13 @@ sequence:
     TEE_Result handle_command_0(void *session, uint32_t cmd_id,
                                 uint32_t param_types, TEE_Param params[4])
     {
-        if ((TEE_PARAM_TYPE_GET(param_types, 0) != TEE_PARAM_TYPE_VALUE_IN) ||
-            (TEE_PARAM_TYPE_GET(param_types, 1) != TEE_PARAM_TYPE_VALUE_OUT) ||
-            (TEE_PARAM_TYPE_GET(param_types, 2) != TEE_PARAM_TYPE_MEMREF_INOUT) ||
-            (TEE_PARAM_TYPE_GET(param_types, 3) != TEE_PARAM_TYPE_NONE)) {
-            return TEE_ERROR_BAD_PARAMETERS
-        }
+        uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+                                                   TEE_PARAM_TYPE_VALUE_OUTPUT,
+                                                   TEE_PARAM_TYPE_MEMREF_INOUT,
+                                                   TEE_PARAM_TYPE_NONE);
+
+        if (param_types != exp_param_types)
+            return TEE_ERROR_BAD_PARAMETERS;
 
         /* process command */
         ...

--- a/building/trusted_applications.rst
+++ b/building/trusted_applications.rst
@@ -300,10 +300,18 @@ Checking TA parameters
 **********************
 GlobalPlatforms TEE Client APIs ``TEEC_InvokeCommand()`` and
 ``TEE_OpenSession()`` allow clients to invoke a TA with some invocation
-parameters: values or references to memory buffers. It is mandatory that TA's
-verify the parameters types before using the parameters themselves. For this a
-TA can rely on the macro ``TEE_PARAM_TYPE_GET(param_type, param_index)`` to get
-the type of a parameter and check its value according to the expected parameter.
+parameters: values or references to memory buffers. It is **mandatory** that
+TA's verify the parameters types before using the parameters themselves. For
+this a TA can rely on the macro ``TEE_PARAM_TYPE_GET(param_type, param_index)``
+to get the type of a parameter and check its value according to the expected
+parameter.
+
+.. warning::
+  Missing verification of expected parameter types may expose arbitrary
+  read-and-write exploit primitives within the affected Trusted Application
+  (TA), potentially leading to partial control over the TEE in the worst-case
+  scenario. For more information, please refer to the GlobalConfusion_ paper,
+  which provides detailed insights into this issue.
 
 For example, if a TA expects that command ID 0 comes with ``params[0]`` being a
 input value, ``params[1]`` being a output value, and ``params[2]`` being a
@@ -537,3 +545,4 @@ They were merely provided in this example for completeness. Consult ``sign_encry
 for a full list of options and parameters.
 
 .. _tee_session_calc_client_uuid(): https://elixir.bootlin.com/linux/latest/A/ident/tee_session_calc_client_uuid
+.. _GlobalConfusion: https://hexhive.epfl.ch/publications/files/24SEC4.pdf


### PR DESCRIPTION
Fixes potential future security vulnerabilites by highlighting the importance of verifying expected parameter types in Trusted Applications, as discussed in the GlobalConfusion paper [1] by Marcel Busch et al.

Note that a proposed fix (and a proof of concept using OP-TEE) is suggested in the same paper, which involves requiring TA writers to register expected function parameters. However, this change has not yet been added to any GlobalPlatform specifications (there is a discussion ongoing).

Link: [1] https://hexhive.epfl.ch/publications/files/24SEC4.pdf