### PR TITLE
describe tee.bin and tee-raw.bin in the porting guidelines

### DIFF
--- a/architecture/porting_guidelines.rst
+++ b/architecture/porting_guidelines.rst
@@ -108,37 +108,12 @@ this (here we are excluding the necessary license header to save some space):
 
     #include <console.h>
     #include <drivers/serial8250_uart.h>
-    #include <kernel/generic_boot.h>
-    #include <kernel/panic.h>
-    #include <kernel/pm_stubs.h>
     #include <mm/core_mmu.h>
     #include <platform_config.h>
     #include <stdint.h>
     #include <tee/entry_fast.h>
     #include <tee/entry_std.h>
-    
-    static void main_fiq(void)
-    {
-    	panic();
-    }
-    
-    static const struct thread_handlers handlers = {
-    	.std_smc = tee_entry_std,
-    	.fast_smc = tee_entry_fast,
-    	.nintr = main_fiq,
-    	.cpu_on = cpu_on_handler,
-    	.cpu_off = pm_do_nothing,
-    	.cpu_suspend = pm_do_nothing,
-    	.cpu_resume = pm_do_nothing,
-    	.system_off = pm_do_nothing,
-    	.system_reset = pm_do_nothing,
-    };
-    
-    const struct thread_handlers *generic_boot_get_handlers(void)
-    {
-    	return &handlers;
-    }
-    
+
     /*
      * Register the physical memory area for peripherals etc. Here we are
      * registering the UART console.

--- a/architecture/porting_guidelines.rst
+++ b/architecture/porting_guidelines.rst
@@ -182,6 +182,15 @@ typically will need to be shared with normal world, so there is need for some
 kind of memory firewall for this (more about that further down). As you can see
 we have also added the UART configuration here, i.e., the ``DEVICE0_xyz`` part.
 
+Flashing
+========
+
+Flashing and loading OP-TEE is highly platform specific. If you just want to get things
+up and running (i.e. by loading OP-TEE via JTAG) the most important thing to know
+is that you should be using the ``tee-raw.bin`` file, this contains just the executable
+code. The ``tee.bin`` file contains the same code but has a header at the start which
+is not executable.
+
 Official board support in OP-TEE?
 =================================
 We do encourage everyone to submit their board support to the OP-TEE project


### PR DESCRIPTION
For someone just trying to launch OP-TEE and print "Hello World!",
tee.bin seems like the obvious binary to use. However it contains a
non-executable header(?!) which can cause some lost days of debugging.

Add a mention that tee-raw.bin should be used as it can just be jumped
to.

cc @jenswi-linaro
