### PR TITLE
architecture: core: fix IRQ/FIQ masked state in diagram

### DIFF
--- a/architecture/core.rst
+++ b/architecture/core.rst
@@ -159,6 +159,7 @@ with IRQ and FIQ masked. SMCs are categorised in two flavors: **fast** and
     participant "OP-TEE OS" as optee
     == IRQ and FIQ unmasked ==
     nwd -> smon : smc: TEE_FUNC_INVOKE
+    == IRQ and FIQ masked ==
     smon -> smon : Save non-secure context
     smon -> smon : Restore secure context
     smon --> entry : eret: TEE_FUNC_INVOKE


### PR DESCRIPTION
The diagram indicates that IRQ/FIQ are unmasked when entering the Trusted OS. This is likely a typo, as the documentation indicates that both blocking and yielding SMCs start with IRQ/FIQs masked, and the code seem to agree as well.