### PR TITLE
dockerfiles: change from xalan to xsltproc

### DIFF
--- a/building/Dockerfile.Ubuntu-20.04
+++ b/building/Dockerfile.Ubuntu-20.04
@@ -48,6 +48,7 @@ RUN apt install -y \
     uuid-dev \
     wget \
     xdg-utils \
+    xsltproc \
     xterm \
     xz-utils \
     zlib1g-dev

--- a/building/Dockerfile.Ubuntu-22.04
+++ b/building/Dockerfile.Ubuntu-22.04
@@ -49,8 +49,8 @@ RUN apt install -y \
     unzip \
     uuid-dev \
     wget \
-    xalan \
     xdg-utils \
+    xsltproc \
     xterm \
     xz-utils \
     zlib1g-dev


### PR DESCRIPTION
Given the varying xalan versions and their distinct behavior on different distributions, adopting xsltproc as a replacement offers consistent multi-distro support, as it appears to be compatible with most platforms.

I haven't tested the 20.04 Dockerfile, if @jforissier has time and ability to do so, it'd be appreciated.

Related to: https://github.com/OP-TEE/optee_test/pull/761