### PR TITLE
dockerfiles: fix build on Ubuntu 22.04

### DIFF
--- a/building/Dockerfile.Ubuntu-22.04
+++ b/building/Dockerfile.Ubuntu-22.04
@@ -1,5 +1,6 @@
 FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
+ENV FORCE_UNSAFE_CONFIGURE=1
 RUN apt update && apt upgrade -y
 RUN apt install -y \
     adb \
@@ -43,6 +44,7 @@ RUN apt install -y \
     python3-pip \
     python3-pyelftools \
     python3-serial \
+    python3-tomli \
     python-is-python3 \
     rsync \
     swig \
@@ -59,5 +61,5 @@ RUN mkdir /optee
 WORKDIR /optee
 RUN repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml && repo sync -j10
 WORKDIR /optee/build
-RUN make -j2 toolchains
+RUN make -j3 toolchains
 RUN make -j$(nproc) check


### PR DESCRIPTION
When using the Ubuntu 22.04 Dockerfile found on the prerequisites page, a build error occurs:

  found no usable tomli, please install it
  make: *** [Makefile:293: /optee/build/../qemu/build/config-host.mak] Error 1

This is caused by a QEMU upgrade. The python3-tomli package needs to be added to the apt install command.

Another error is:

  checking whether mknod can create fifo without root privileges... configure: error: in `/optee/out-br/build/host-tar-1.35':
  configure: error: you should not run configure as root (set FORCE_UNSAFE_CONFIGURE=1 in environment to bypass this check)

...so let's set FORCE_UNSAFE_CONFIGURE=1.

Setting -j3 instead of -j2 for "make toolchain" is unrelated but is slightly faster so let's improve that too.