### PR TITLE
Fix failing docker build on Ubuntu 22.04

### DIFF
--- a/building/Dockerfile.Ubuntu-22.04
+++ b/building/Dockerfile.Ubuntu-22.04
@@ -1,8 +1,8 @@
 FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 ENV FORCE_UNSAFE_CONFIGURE=1
-RUN apt update && apt upgrade -y
-RUN apt install -y \
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y \
     adb \
     acpica-tools \
     autoconf \
@@ -22,6 +22,7 @@ RUN apt install -y \
     ftp-upload \
     gdisk \
     git \
+    libgnutls28-dev \
     libattr1-dev \
     libcap-ng-dev \
     libfdt-dev \


### PR DESCRIPTION
Running `docker build` on the provided Dockerfile is failing due to a missing dependency, `libgnutls28-dev`. I have added it and also updated the build commands to use `apt-get` instead of `apt`, as it is preferable to use `apt-get` when running in a non-interactive context like `docker build`.