### PR TITLE
Fix formatting of first-level subkey description

### DIFF
--- a/architecture/subkeys.rst
+++ b/architecture/subkeys.rst
@@ -117,7 +117,7 @@ second-level subkey above it would look like this:
 +------------------+----------------------+-----------------------------------+
 | Size in bytes    | Binary               |                                   |
 +------------------+----------------------+-----------------------------------+
-| first.img_size   | First-level subkey     | Signed by Root key              |
+| first.img_size   | First-level subkey   | Signed by Root key                |
 +------------------+----------------------+-----------------------------------+
 | first.name_size  | UUIDv5 name string   | Not signed, used to prove that    |
 |                  | for the next subkey  | the next UUID is in the namespace |


### PR DESCRIPTION
The table formatting here is weird:
https://optee.readthedocs.io/en/latest/architecture/subkeys.html#subkeys
<img width="1075" height="552" alt="image" src="https://github.com/user-attachments/assets/59785900-2b81-4aa3-923d-0d2f58765a97" />


Not sure if this fits here, but here is a PR. 👍 