### PR TITLE
Fix bug in rpi3 build instructions

### DIFF
--- a/building/devices/rpi3.rst
+++ b/building/devices/rpi3.rst
@@ -348,7 +348,14 @@ the image generated during the build process for our device.
 .. code-block:: bash
 
     $ sudo losetup -Pf <rpi3-project>/out/rpi3-sdcard.img
-    $ sudo mount /dev/loop0p2 /mnt
+    $ losetup -a | grep rpi3
+
+The latter command shows you which ``/dev/loop*`` file is associated
+with ``rpi3-sdcard.img``. Use this number to replace <num> in two commands below:
+
+.. code-block:: bash
+
+    $ sudo mount /dev/loop<num>p2 /mnt
 
 If there were no errors when running the above, then you should be able to see
 the root filesystem file at ``/mnt`` and we're now ready to copy the content to
@@ -359,7 +366,7 @@ the NFS share we've defined.
     $ cd /srv/nfs/rpi
     $ sudo cp -a /mnt/* .
     $ sudo umount /mnt
-    $ sudo losetup -d /dev/loop0
+    $ sudo losetup -d /dev/loop<num>
 
 .. hint::
 


### PR DESCRIPTION
In the [rpi3 instructions](https://optee.readthedocs.io/en/latest/building/devices/rpi3.html), after I ran `sudo losetup -Pf <rpi3-project>/out/rpi3-sdcard.img`, the next command `sudo mount /dev/loop0p2 /mnt` didn't work.

This is because `rpi3-sdcard.img` was associated with `/dev/loop44` for me, not `/dev/loop0`.

```
❯ losetup -a | grep rpi3
/dev/loop44: []: (/home/jesse/Documents/GitHub/c2patee/optee_rpi3/out/rpi3-sdcard.img)
```

I updated the instructions to say that the user should run `losetup -a | grep rpi3` to check which `/dev/loop*` file to use.