### PR TITLE
platforms: remove broken Versal NET named reference

### DIFF
--- a/general/platforms.rst
+++ b/general/platforms.rst
@@ -298,7 +298,7 @@ please refer to the file MAINTAINERS_ for contact details for various platforms.
      - Yes
      - Yes
 
-   * - `AMD/Xilinx Versal NET`_
+   * - AMD/Xilinx Versal NET
      - ``PLATFORM=versal-net``
      - No
      - Yes


### PR DESCRIPTION
AMD/Xilinx Versal NET has no public product page, so drop the unresolved Sphinx named reference rather than leaving a broken link in the table.