### PR TITLE
building: versal: Fix typo, code-block caption tag

### DIFF
--- a/building/devices/versal.rst
+++ b/building/devices/versal.rst
@@ -728,8 +728,7 @@ parameters.
     bytes, unless the buffer is supposed to be a single item of a certain type.
 
 .. code-block:: c
-    : caption: Example - Extending and reading Hardware PCR from within OP-TEE
-               OS
+    :caption: Example - Extending and reading Hardware PCR from within OP-TEE OS
 
     #include <drivers/versal_ocp.h>
 


### PR DESCRIPTION
This pull request is a follow-up of PR #280.

An extra space crept into the code-block `caption` marker and caused the code-block to disappear when rendered.