### PR TITLE
General: update some dead links

### DIFF
--- a/general/about.rst
+++ b/general/about.rst
@@ -78,10 +78,10 @@ June 12 2014 was the day when OP-TEE was "born" as an open source project. At
 that day the OP-TEE team pushed the `first commit
 <https://github.com/OP-TEE/optee_os/commit/b01047730e77127c23a36591643eeb8bb0487d68>`_
 to GitHub. A bit after this Linaro also made a `press release
-<https://www.linaro.org/blog/op-tee-open-source-security-mass-market/>`_ about
-this. That press release contains a bit more information. At the first year as
-an open source project it was owned by STMicroelectronics but maintained by
-Linaro and STMicroelectronics. In 2015 there was an ownership transfer of
+<https://web.archive.org/web/20230511115829/https:/www.linaro.org/blog/op-tee-open-source-security-mass-market/>`_
+about this. That press release contains a bit more information. At the first
+year as an open source project it was owned by STMicroelectronics but maintained
+by Linaro and STMicroelectronics. In 2015 there was an ownership transfer of
 OP-TEE from STMicroelectronics to Linaro. In September 2019, ownership was
 transferred from Linaro to the TrustedFirmware.org project (see _blogpost for
 more information). Maintenance is a shared responsibility between the members

--- a/general/contact.rst
+++ b/general/contact.rst
@@ -85,7 +85,7 @@ incidents.
 .. _GitHub Security Advisories: https://github.com/OP-TEE/optee_os/security/advisories
 .. _issues: https://help.github.com/articles/about-issues/
 .. _issues at optee_os: https://github.com/OP-TEE/optee_os/issues
-.. _Mailing Aliases: https://developer.trustedfirmware.org/w/collaboration/security_center/mailing_aliases
+.. _Mailing Aliases: https://general.docs.trustedfirmware.org/en/latest/security_center/mailing_aliases.html
 .. _OP-TEE MAINTAINERS: https://github.com/OP-TEE/optee_os/blob/master/MAINTAINERS
-.. _TrustedFirmware.org security incident: https://developer.trustedfirmware.org/w/collaboration/security_center
+.. _TrustedFirmware.org security incident: https://general.docs.trustedfirmware.org/en/latest/security_center/index.html
 .. _TrustedFirmware.org FAQ: https://www.trustedfirmware.org/faq/


### PR DESCRIPTION
The Trusted Firmware developer[1] server do no more exist. The security center pages were moved to a Trusted Firmware documentation repository [2]. Update the contact page accordingly.
The Linaro blog announcing the birth of the open source project[3] is no more accessible. Use the Internet Archive Wayback Machine instead.

[1]: https://developer.trustedfirmware.org
[2]: https://general.docs.trustedfirmware.org/en/latest/security_center/
[3]: https://www.linaro.org/blog/op-tee-open-source-security-mass-market