### PR TITLE
platforms: add Qualcomm platform documentation

### DIFF
--- a/architecture/platforms/index.rst
+++ b/architecture/platforms/index.rst
@@ -8,3 +8,4 @@ Platform documentation
     :maxdepth: 1
 
     nxp
+    qualcomm/index

--- a/architecture/platforms/qualcomm/bobcat.rst
+++ b/architecture/platforms/qualcomm/bobcat.rst
@@ -1,0 +1,23 @@
+.. _qualcomm_bobcat:
+
+###################
+Bobcat architecture
+###################
+
+The Bobcat family targets Qualcomm networking processors. It currently covers
+the ``ipq96xx`` and ``ipq52xx`` chipsets.
+
+On top of the :ref:`common platform support <qualcomm>`, Bobcat currently
+provides a minimal, family-specific configuration. Additional drivers and
+services will be enabled as support evolves.
+
+Chipsets
+********
+
+ipq96xx
+=======
+5-core configuration with a GICv3 interrupt controller (``CFG_ARM_GICV3``).
+
+ipq52xx
+=======
+4-core configuration.

--- a/architecture/platforms/qualcomm/hoya.rst
+++ b/architecture/platforms/qualcomm/hoya.rst
@@ -1,0 +1,50 @@
+.. _qualcomm_hoya:
+
+#################
+Hoya architecture
+#################
+
+The Hoya family targets Qualcomm application processors. It currently covers the
+``kodiak`` and ``lemans`` chipsets.
+
+On top of the :ref:`common platform support <qualcomm>`, Hoya enables an 8-core
+Cortex-A (ARMv8) configuration with a GICv3 interrupt controller
+(``CFG_ARM_GICV3``).
+
+Drivers and services
+*********************
+The following drivers and services are available on the Hoya architecture:
+
+	- **RAMBLUR inline memory protection (v3)**
+	  (``CFG_QCOM_RAMBLUR_PIMEM_V3``) providing anti-rollback, integrity and
+	  confidentiality protection for secure memory windows.
+	- **Secure PRNG** hardware random number generator (``CFG_QCOM_PRNG``) used
+	  as the entropy source for ``hw_get_random_bytes()``.
+	- **Qualcomm clock driver** (``CFG_DRIVERS_QCOM_CLK``) built on the OP-TEE
+	  clock framework (``CFG_DRIVERS_CLK``).
+	- **Command DB** (``CFG_QCOM_CMD_DB``), a read-only shared database used to
+	  look up RPMh resource addresses and metadata.
+	- **RPMh client** (``CFG_QCOM_RPMH_CLIENT``) to vote for shared resources
+	  (clocks, regulators, etc.) through the RPMh subsystem. It depends on the
+	  Command DB driver.
+	- **QFPROM fuse provisioning** (``CFG_QCOM_QFPROM`` /
+	  ``CFG_QCOM_QFPROM_FUSEPROV``) for reading and blowing one-time-programmable
+	  fuses. Fuse provisioning is enabled by default on secure builds and
+	  depends on the Command DB and RPMh client drivers.
+
+Chipsets
+********
+
+Kodiak
+======
+In addition to the Hoya features above, the ``kodiak`` chipset enables the
+**Peripheral Authentication Service (PAS)** pseudo TA (``CFG_QCOM_PAS_PTA``).
+The PAS PTA authenticates and brings up remote subsystems such as the audio
+DSP (LPASS/QDSP6), the compute DSP (Turing) and the Wi-Fi processor subsystem
+(WPSS). It also applies the MX voltage-rail workaround required for QFPROM fuse
+blowing on this chipset (``CFG_QFPROM_MX_RAIL_WA``).
+
+Lemans
+======
+The ``lemans`` chipset enables the Hoya drivers and services described above,
+including the Qualcomm clock driver and QFPROM fuse provisioning.

--- a/architecture/platforms/qualcomm/index.rst
+++ b/architecture/platforms/qualcomm/index.rst
@@ -1,0 +1,67 @@
+.. _qualcomm:
+
+########
+Qualcomm
+########
+
+OP-TEE supports Qualcomm SoCs through the ``plat-qcom`` platform. The platform
+is organised around *architecture families*, where each family groups a set of
+chipsets (``PLATFORM_FLAVOR``) that share the same CPU topology, drivers and
+memory layout.
+
+Supported architectures
+***********************
+The following architecture families and chipsets are currently supported:
+
+	- :ref:`qualcomm_hoya` – application processors
+		- ``kodiak``
+		- ``lemans``
+	- :ref:`qualcomm_bobcat` – networking processors
+		- ``ipq96xx``
+		- ``ipq52xx``
+
+.. note::
+
+	Driver and feature support for both architecture families is still a
+	work in progress. The per-architecture pages reflect the current state
+	of the upstream port and are expected to grow over time.
+
+To build for a given chipset, select the Qualcomm platform and the matching
+flavor, for example:
+
+.. code-block:: bash
+
+	$ make PLATFORM=qcom PLATFORM_FLAVOR=kodiak
+
+Common platform support
+***********************
+The following features are enabled for every Qualcomm chipset, regardless of the
+architecture family:
+
+	- **Boot flow** based on Arm Trusted Firmware (``CFG_WITH_ARM_TRUSTED_FW``)
+	  with an AArch64 secure core (``CFG_ARM64_core``) using a 40-bit physical
+	  address space (``CFG_CORE_LARGE_PHYS_ADDR``).
+	- **GIC** interrupt controller (``CFG_GIC``).
+	- **Secure time** sourced from the physical counter ``CNTPCT``
+	  (``CFG_SECURE_TIME_SOURCE_CNTPCT``).
+	- **GENI serial engine UART** console driver (``CFG_QCOM_GENI_UART``). The
+	  UART is shared with the non-secure world, so the ready-wait period is
+	  tunable per platform via ``CFG_QCOM_GENI_UART_RDY_WAIT_USEC``.
+	- **Arm Crypto Extensions** acceleration (``CFG_CRYPTO_WITH_CE``), which in
+	  turn enables CE-accelerated AES, AES-GCM and SHA-1/SHA-256.
+	- The **Hardware Unique Key** length is set to 32 bytes
+	  (``CFG_HW_UNIQUE_KEY_LENGTH``). Note that the platform does not yet provide
+	  its own ``tee_otp_get_hw_unique_key()`` implementation, so the default
+	  (test) key from the OP-TEE core is used unless a board-specific provider is
+	  added.
+
+Per-architecture documentation
+******************************
+Refer to the architecture-specific pages below for the drivers, services and
+configuration available on each architecture family and its chipsets:
+
+.. toctree::
+	:maxdepth: 1
+
+	hoya
+	bobcat


### PR DESCRIPTION
Document the plat-qcom platform, organised by architecture family (Hoya and Bobcat), describing the common platform support along with the drivers and features enabled for each architecture and chipset.